### PR TITLE
Fix: Enable URL clicking in terminal with Tauri opener plugin

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:event:allow-listen",
     "core:event:allow-emit",
-    "opener:default"
+    "opener:default",
+    "opener:allow-open-url"
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,9 @@
             "dialog:default",
             "updater:default",
             "updater:allow-check",
-            "updater:allow-download-and-install"
+            "updater:allow-download-and-install",
+            "opener:default",
+            "opener:allow-open-url"
           ]
         }
       ]

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import '@xterm/xterm/css/xterm.css';
 
 interface TerminalProps {
@@ -88,7 +89,17 @@ export const Terminal = React.forwardRef<{ focus: () => void }, TerminalProps>((
 
     // Add addons
     const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
+    
+    // Custom link handler for Tauri desktop app
+    const handleLinkClick = async (_event: MouseEvent, uri: string) => {
+      try {
+        await openUrl(uri);
+      } catch (error) {
+        console.error('Failed to open link:', uri, error);
+      }
+    };
+    
+    const webLinksAddon = new WebLinksAddon(handleLinkClick);
     
     xterm.loadAddon(fitAddon);
     xterm.loadAddon(webLinksAddon);


### PR DESCRIPTION
## Summary
Fixed URLs not being clickable in the terminal component. Users were seeing URL underlines on Cmd+hover but clicking had no effect or showed permission errors.

## Root Cause
The xterm.js WebLinksAddon was using the default `window.open()` behavior, which doesn't work in Tauri desktop apps. Additionally, the required `opener:allow-open-url` permission was missing from the Tauri configuration.

## Changes Made
- **Terminal.tsx**: Added custom link handler using Tauri's `openUrl()` API instead of default browser behavior
- **Tauri permissions**: Added `opener:allow-open-url` to both `default.json` and `tauri.conf.json` capabilities
- **Import**: Added `@tauri-apps/plugin-opener` import for the `openUrl` function

## Technical Details
1. Replaced default WebLinksAddon with custom handler that uses `openUrl(uri)` 
2. Added proper error handling for failed link opening attempts
3. Ensured Tauri security permissions allow URL opening in external browser

## Test Plan
- [x] Open terminal in app
- [x] Type command with URL output (e.g., `echo "https://github.com"`)
- [x] Hover URL with Cmd key - see underline
- [x] Click URL - opens in default browser
- [x] No permission errors in console

## Before/After
**Before**: URLs showed underline on hover but clicking did nothing or showed "opener.open_url not allowed" error
**After**: URLs properly open in system's default browser when clicked

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>